### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 fastapi
 uvicorn
+
+pytest
+requests
+
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for varsity and JV levels",
+        "schedule": "Mondays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and participate in friendly matches",
+        "schedule": "Wednesdays and Saturdays, 10:00 AM - 11:30 AM",
+        "max_participants": 10,
+        "participants": ["lucas@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Perform in theatrical productions and develop acting skills",
+        "schedule": "Tuesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": ["isabella@mergington.edu", "jacob@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and sculpture techniques",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:45 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Engage in competitive debate and public speaking",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["ryan@mergington.edu", "sophie@mergington.edu"]
+    },
+    "Robotics Club": {
+        "description": "Design and build robots for competitions",
+        "schedule": "Wednesdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["noah@mergington.edu"]
     }
 }
 
@@ -61,7 +97,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
-
+    
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,21 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity."""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -25,6 +25,12 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants">
+            <h5>Participants:</h5>
+            <ul>
+              ${details.participants.map(participant => `<li>${participant}</li>`).join('')}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,6 +12,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      // Reset activity select so repeated fetches don't duplicate options
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -21,19 +23,65 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft = details.max_participants - details.participants.length;
 
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants">
-            <h5>Participants:</h5>
-            <ul>
-              ${details.participants.map(participant => `<li>${participant}</li>`).join('')}
-            </ul>
-          </div>
-        `;
+            <h4>${name}</h4>
+            <p>${details.description}</p>
+            <p><strong>Schedule:</strong> ${details.schedule}</p>
+            <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+            <div class="participants">
+              <h5>Participants:</h5>
+              <ul>
+                ${details.participants
+                  .map(
+                    (participant) =>
+                      `<li class="participant-item"><span class="participant-email">${participant}</span><button class="delete-btn" data-activity="${name}" data-email="${participant}" title="Unregister">✕</button></li>`
+                  )
+                  .join("")}
+              </ul>
+            </div>
+          `;
 
         activitiesList.appendChild(activityCard);
+
+          // Attach delete handlers for participants in this card
+          activityCard.querySelectorAll('.delete-btn').forEach((btn) => {
+            btn.addEventListener('click', async (e) => {
+              const activityName = btn.dataset.activity;
+              const email = btn.dataset.email;
+
+              try {
+                const response = await fetch(
+                  `/activities/${encodeURIComponent(activityName)}/unregister?email=${encodeURIComponent(email)}`,
+                  { method: 'DELETE' }
+                );
+
+                const result = await response.json();
+
+                if (response.ok) {
+                  messageDiv.textContent = result.message;
+                  messageDiv.className = 'success';
+                  messageDiv.classList.remove('hidden');
+                  // Refresh the activities list to reflect the change
+                  fetchActivities();
+                } else {
+                  messageDiv.textContent = result.detail || 'An error occurred';
+                  messageDiv.className = 'error';
+                  messageDiv.classList.remove('hidden');
+                }
+
+                setTimeout(() => {
+                  messageDiv.classList.add('hidden');
+                }, 4000);
+              } catch (error) {
+                console.error('Error unregistering:', error);
+                messageDiv.textContent = 'Failed to unregister. Please try again.';
+                messageDiv.className = 'error';
+                messageDiv.classList.remove('hidden');
+                setTimeout(() => {
+                  messageDiv.classList.add('hidden');
+                }, 4000);
+              }
+            });
+          });
 
         // Add option to select dropdown
         const option = document.createElement("option");
@@ -68,6 +116,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh activities so UI shows the newly added participant
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -48,3 +48,16 @@
     <script src="app.js"></script>
   </body>
 </html>
+
+<div class="activity-card">
+  <!-- Existing activity card code... -->
+  <div class="participants">
+    <h5>Participants:</h5>
+    <ul>
+      <li>Participant 1</li>
+      <li>Participant 2</li>
+      <li>Participant 3</li>
+    </ul>
+  </div>
+  <!-- Existing activity card code... -->
+</div>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -88,9 +88,40 @@ section h3 {
 }
 
 .activity-card .participants ul {
-  list-style-type: disc;
-  padding-left: 20px;
+  list-style-type: none;
+  padding-left: 0;
   margin: 0;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+.participant-item + .participant-item {
+  margin-top: 6px;
+}
+
+.participant-email {
+  color: #333;
+  word-break: break-all;
+}
+
+.delete-btn {
+  background: transparent;
+  border: none;
+  color: #c62828;
+  font-weight: bold;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.delete-btn:hover {
+  background-color: rgba(198, 40, 40, 0.08);
 }
 
 .form-group {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,25 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.activity-card .participants {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f0f8ff;
+}
+
+.activity-card .participants h5 {
+  margin-bottom: 5px;
+  color: #1a237e;
+}
+
+.activity-card .participants ul {
+  list-style-type: disc;
+  padding-left: 20px;
+  margin: 0;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,45 @@
+from fastapi.testclient import TestClient
+from src.app import app
+
+client = TestClient(app)
+
+
+def test_get_activities():
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # basic sanity: one known activity should exist
+    assert "Chess Club" in data
+
+
+def test_signup_and_unregister_flow():
+    activity = "Chess Club"
+    email = "testuser@example.com"
+
+    # ensure the email is not already present
+    resp = client.get("/activities")
+    assert resp.status_code == 200
+    assert email not in resp.json()[activity]["participants"]
+
+    # sign up
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp.status_code == 200
+    assert "Signed up" in resp.json()["message"]
+
+    # verify presence
+    resp = client.get("/activities")
+    assert email in resp.json()[activity]["participants"]
+
+    # duplicate signup should be rejected
+    resp = client.post(f"/activities/{activity}/signup", params={"email": email})
+    assert resp.status_code == 400
+
+    # unregister
+    resp = client.delete(f"/activities/{activity}/unregister", params={"email": email})
+    assert resp.status_code == 200
+    assert "Unregistered" in resp.json()["message"]
+
+    # verify removal
+    resp = client.get("/activities")
+    assert email not in resp.json()[activity]["participants"]


### PR DESCRIPTION
Summary

Small feature to allow unregistering participants from activities directly in the UI, plus related UX and tests.
What I changed

Backend: added DELETE /activities/{activity_name}/unregister to remove a participant (app.py).
Frontend: render a red ✕ delete button next to each participant and attach click handlers that call the unregister endpoint; refresh activities after signup/unregister (app.js).
Styles: hide list bullets and style participant rows and delete button (styles.css).
Tests: added pytest tests covering get, signup, duplicate signup, and unregister flows (test_app.py).
Deps: updated requirements.txt to include test packages: pytest, requests, httpx.
Behavior / User flow

Participants are shown without bullets and with a delete button.
Clicking the delete button calls the new backend endpoint, removes the participant, and refreshes the UI with a success/error message.
Signing up via the form immediately refreshes the participants list (no manual page reload needed).
How to run locally

Install dependencies:

/workspaces/gh-copilot-learn/.venv/bin/python -m pip install -r requirements.txt
Start dev server:

uvicorn src.app:app --reload
Run tests:

/workspaces/gh-copilot-learn/.venv/bin/python -m pytest -q
Notes & limitations

Activities are stored in-memory; unregister/signup changes are not persisted across restarts. Consider adding persistent storage if needed.
The delete action is immediate; there is no confirmation prompt. If you want an “Are you sure?” modal or a trash SVG icon instead of ✕, I can add it.
Suggested follow-ups

Add a confirmation dialog before unregistering.
Replace text ✕ with an accessible SVG icon and aria-labels.
Add a GitHub Actions workflow to run tests on PRs.